### PR TITLE
Use environment variables instead of hardcodec container names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ ARG VERSION=unknown
 ARG COMMIT=unknown
 ARG CREATED="an unknown date"
 ENV TZ=Europe/London
+ENV QBITTORRENT_CONTAINER_NAME=qbittorrent
+ENV GLUETUN_CONTAINER_NAME=gluetun
 
 LABEL \
     org.opencontainers.image.authors="jakubkopys95@gmail.com" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     network_mode: none # it doesn't need internet connectivity, it's more secure this way
     environment:
       - TZ=Europe/London
+      - QBITTORRENT_CONTAINER_NAME=qbittorrent
+      - GLUETUN_CONTAINER_NAME=gluetun
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     # normally, you'd have gluetun and qibtorrent services here too

--- a/restart-qbittorrent.sh
+++ b/restart-qbittorrent.sh
@@ -8,37 +8,50 @@ log_message() {
 }
 
 is_gluetun_running() {
-  docker ps --filter "name=gluetun" --filter "status=running" --format '{{.Names}}' | grep -w "gluetun" > /dev/null 2>&1
+  docker ps --filter "name=$GLUETUN_CONTAINER_NAME" --filter "status=running" --format '{{.Names}}' | grep -w "$GLUETUN_CONTAINER_NAME" > /dev/null 2>&1
 }
 
 wait_for_gluetun() {
-  log_message "Waiting for the 'gluetun' container to start..."
+  log_message "Waiting for the '$GLUETUN_CONTAINER_NAME' container to start..."
   until is_gluetun_running; do
     sleep 60
   done
-  log_message "'gluetun' container is running."
+  log_message "$GLUETUN_CONTAINER_NAME container is running."
 }
 
 while true; do
   wait_for_gluetun
 
-  log_message "Listening to 'gluetun' logs..."
-  docker logs -f -n 0 gluetun | while read line; do
+  # Check if environment variables are set
+  if [ -z "$GLUETUN_CONTAINER_NAME" ] || [ -z "$QBITTORRENT_CONTAINER_NAME" ]; then
+    # check gluetun container name set
+    if [ -z "$GLUETUN_CONTAINER_NAME" ]; then
+      log_message "Environment variable GLUETUN_CONTAINER_NAME is not set. Run 'export GLUETUN_CONTAINER_NAME=gluetun' to set it."
+    fi
+    # check qbittorrent container name set
+    if [ -z "$QBITTORRENT_CONTAINER_NAME" ]; then
+      log_message "Environment variable QBITTORRENT_CONTAINER_NAME is not set. Run 'export QBITTORRENT_CONTAINER_NAME=qbittorrent' to set it."
+    fi
+    exit 1
+  fi
+
+  log_message "Listening to '$GLUETUN_CONTAINER_NAME' logs..."
+  docker logs -f -n 0 $GLUETUN_CONTAINER_NAME | while read line; do
       # Check if the line contains "ip getter"
       # Gluetun logs "ip getter" after it successfuly restarts/reconnects - that's when we want to
       # restart qbittorrent
       if [[ "$line" == *"ip getter"* ]]; then
-          log_message "Detected 'ip getter' event. Restarting qbittorrent container..."
+          log_message "Detected 'ip getter' event. Restarting '$QBITTORRENT_CONTAINER_NAME' container..."
 
-          if docker restart qbittorrent -t 120; then
-              log_message "qbittorrent container restarted successfully."
+          if docker restart $QBITTORRENT_CONTAINER_NAME -t 120; then
+              log_message "$QBITTORRENT_CONTAINER_NAME container restarted successfully."
           else
-              log_message "Failed to restart qbittorrent container."
+              log_message "Failed to restart $QBITTORRENT_CONTAINER_NAME container."
           fi
       fi
   done
   if [ $? -ne 0 ]; then
-    log_message "'gluetun' container has stopped or an error occurred."
+    log_message "$GLUETUN_CONTAINER_NAME container has stopped or an error occurred."
   fi
 
   log_message "Restarting log monitoring..."


### PR DESCRIPTION
I didnt make this code, but the person who did in their fork didnt make a PR and does not have issues enabled, so there is no easy way to ask them to make a PR for it.

I had the same idea, but there is no sense in redoing already done work, so all i did was cherry pick the commit onto my own fork and make the PR. 